### PR TITLE
fix: building with nginx with HTTP/3

### DIFF
--- a/.github/workflows/nginx-otel-build.yml
+++ b/.github/workflows/nginx-otel-build.yml
@@ -1,0 +1,18 @@
+name: nginx-otel-build
+run-name: ${{ github.actor }} is triggering pipeline
+on: [push]
+jobs:
+  build-and-test-module:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+            sudo apt-get update && sudo apt install -y mercurial cmake \
+            libc-ares-dev libre2-dev libssl-dev zlib1g-dev curl
+      - run: |
+             hg clone http://hg.nginx.org/nginx/ && cd nginx && \
+             auto/configure --with-compat --with-debug --with-http_ssl_module \
+             --with-http_v2_module --with-http_v3_module && make -j 4
+      - run: |
+            mkdir build && cd build && cmake -DNGX_OTEL_NGINX_BUILD_DIR=\
+            ${PWD}/../nginx/objs .. && make -j 4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,10 +117,13 @@ target_include_directories(ngx_otel_module PRIVATE
     ${NGX_OTEL_NGINX_BUILD_DIR}
     ${NGX_OTEL_NGINX_DIR}/src/core
     ${NGX_OTEL_NGINX_DIR}/src/event
+    ${NGX_OTEL_NGINX_DIR}/src/event/modules
+    ${NGX_OTEL_NGINX_DIR}/src/event/quic
     ${NGX_OTEL_NGINX_DIR}/src/os/unix
     ${NGX_OTEL_NGINX_DIR}/src/http
     ${NGX_OTEL_NGINX_DIR}/src/http/modules
     ${NGX_OTEL_NGINX_DIR}/src/http/v2
+    ${NGX_OTEL_NGINX_DIR}/src/http/v3
     ${PROTO_OUT_DIR})
 
 target_link_libraries(ngx_otel_module


### PR DESCRIPTION
### Proposed changes

Fix building nginx-otel module with the latest nginx that supports HTTP/3.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-otel/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-otel/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-otel/blob/main/CHANGELOG.md))
