### PR TITLE
fix: building with nginx with HTTP/3

### DIFF
--- a/.github/workflows/nginx-otel-module-check.yml
+++ b/.github/workflows/nginx-otel-module-check.yml
@@ -1,0 +1,31 @@
+name: nginx-otel-module-check
+run-name: ${{ github.actor }} is triggering pipeline
+on: [push]
+jobs:
+  build-module:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake libc-ares-dev libre2-dev
+      - name: Checkout nginx
+        run: hg clone http://hg.nginx.org/nginx/
+      - name: Configure nginx
+        working-directory: nginx
+        run: auto/configure --with-compat
+      - name: Create build directory
+        run: mkdir build
+      - name: Build module
+        working-directory: build
+        run: |
+          cmake -DNGX_OTEL_NGINX_BUILD_DIR=${PWD}/../nginx/objs ..
+          make -j 4
+          strip ngx_otel_module.so
+      - name: Archive module
+        uses: actions/upload-artifact@v3
+        with:
+          name: nginx-otel-module
+          path: build/ngx_otel_module.so

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,10 +117,13 @@ target_include_directories(ngx_otel_module PRIVATE
     ${NGX_OTEL_NGINX_BUILD_DIR}
     ${NGX_OTEL_NGINX_DIR}/src/core
     ${NGX_OTEL_NGINX_DIR}/src/event
+    ${NGX_OTEL_NGINX_DIR}/src/event/modules
+    ${NGX_OTEL_NGINX_DIR}/src/event/quic
     ${NGX_OTEL_NGINX_DIR}/src/os/unix
     ${NGX_OTEL_NGINX_DIR}/src/http
     ${NGX_OTEL_NGINX_DIR}/src/http/modules
     ${NGX_OTEL_NGINX_DIR}/src/http/v2
+    ${NGX_OTEL_NGINX_DIR}/src/http/v3
     ${PROTO_OUT_DIR})
 
 target_link_libraries(ngx_otel_module


### PR DESCRIPTION
### Proposed changes

Fix building nginx-otel module with the latest nginx that supports HTTP/3.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-otel/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-otel/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-otel/blob/main/CHANGELOG.md))
