### PR TITLE
Prevent crash for HTTP/0.9 requests (fix #22).

### DIFF
--- a/src/http_module.cpp
+++ b/src/http_module.cpp
@@ -243,7 +243,13 @@ ngx_int_t setHeader(ngx_http_request_t* r, StrView name, StrView value)
             return NGX_OK;
         }
 
-        header = (ngx_table_elt_t*)ngx_list_push(&r->headers_in.headers);
+        auto headers = &r->headers_in.headers;
+        if (!headers->pool && ngx_list_init(headers, r->pool, 2,
+                sizeof(ngx_table_elt_t)) != NGX_OK) {
+            return NGX_ERROR;
+        }
+
+        header = (ngx_table_elt_t*)ngx_list_push(headers);
         if (header == NULL) {
             return NGX_ERROR;
         }


### PR DESCRIPTION
Looks like #22 is caused by HTTP/0.9 requests. With given fix I don't see crashes anymore.