### PR TITLE
Build system: provide a way to pass additional options to cmake invoc…

### DIFF
--- a/config
+++ b/config
@@ -7,4 +7,5 @@ cmake -D NGX_OTEL_NGINX_BUILD_DIR=$NGX_OBJS \
       -D "CMAKE_C_FLAGS=$NGX_CC_OPT" \
       -D "CMAKE_CXX_FLAGS=$NGX_CC_OPT" \
       -D "CMAKE_MODULE_LINKER_FLAGS=$NGX_LD_OPT" \
+      $NGINX_OTEL_CMAKE_ADDITIONAL_OPTS \
       -S $ngx_addon_dir -B $NGX_OBJS/otel || exit 1


### PR DESCRIPTION
…ation.

When building otel module as a part of nginx build system process (via `./configure --add-dynamic-module=nginx-otel/`), there is no way to pass additional options to the cmake invocation, making it impossible link the module with desired ssl library variant.

With the patch, it's now possible to pass the additional options, e.g. `NGINX_OTEL_ADDITIONAL_OPTS="-DOPENSSL_ROOT_DIR=/usr/lib64/openssl11;/usr/include/openssl11" ./configure --add-dynamic-module=nginx-otel/`, and cmake will pick up the correct ssl variant to link the module with.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-otel/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-otel/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-otel/blob/main/CHANGELOG.md))
