### PR TITLE
[RFC] Added NGINX Buildsystem github action test.

### DIFF
--- a/.github/workflows/nginx-buildsystem.yml
+++ b/.github/workflows/nginx-buildsystem.yml
@@ -1,0 +1,81 @@
+name: NGINX Build System (Alpine-based)
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  build-module:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jirutka/setup-alpine@v1
+        with:
+          branch: v3.19
+          packages: >
+            cmake
+            g++
+            re2-dev
+            c-ares-dev
+            grpc-dev
+            git
+            protoc
+            make
+            protobuf-dev
+            perl-io-socket-ssl
+            perl-cryptx
+            openssl
+            pcre2-dev
+      - name: Clone dependencies
+        run: |
+          git clone https://github.com/nginx/nginx
+          git clone https://github.com/nginx/nginx-tests
+          git clone https://github.com/open-telemetry/opentelemetry-cpp
+          git clone https://github.com/open-telemetry/opentelemetry-proto
+        shell: alpine.sh {0}
+      - name: Build dependencies
+        working-directory: opentelemetry-cpp
+        run: |
+          cmake \
+          -DCMAKE_CXX_EXTENSIONS=OFF \
+          -DCMAKE_CXX_VISIBILITY_PRESET=hidden \
+          -DCMAKE_POLICY_DEFAULT_CMP0063=NEW \
+          -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/prebuilt/ \
+          -DCMAKE_INSTALL_PREFIX:STRING=$GITHUB_WORKSPACE/prebuilt/ \
+          -DCMAKE_INSTALL_LIBDIR:STRING=lib \
+          -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+          -DBUILD_TESTING=OFF \
+          -DWITH_ABSEIL=ON \
+          -DWITH_BENCHMARK=OFF \
+          -DWITH_EXAMPLES=OFF \
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          . && make -j $(nproc) install
+        shell: alpine.sh {0}
+      - name: Build module
+        working-directory: nginx
+        run: |
+          NGX_OTEL_PROTO_DIR=$GITHUB_WORKSPACE/opentelemetry-proto/ \
+          CMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/prebuilt \
+          ./auto/configure --add-dynamic-module=$GITHUB_WORKSPACE/ \
+          --with-compat \
+          && make -j $(nproc) modules
+        shell: alpine.sh {0}
+      - name: Build nginx
+        working-directory: nginx
+        run: |
+          make -j $(nproc)
+        shell: alpine.sh {0}
+      - name: Download otelcol
+        run: |
+          curl -LO https://github.com/\
+          open-telemetry/opentelemetry-collector-releases/releases/download/\
+          v0.76.1/otelcol_0.76.1_linux_amd64.tar.gz
+          tar -xzf otelcol_0.76.1_linux_amd64.tar.gz
+        shell: alpine.sh {0}
+      - name: Run tests
+        working-directory: nginx-tests
+        run: |
+          PERL5LIB=$GITHUB_WORKSPACE/nginx-tests/lib TEST_NGINX_UNSAFE=1 \
+          TEST_NGINX_VERBOSE=1 TEST_NGINX_GLOBALS="load_module \
+            ${GITHUB_WORKSPACE}/nginx/objs/ngx_otel_module.so;" prove -v .
+        shell: alpine.sh {0}


### PR DESCRIPTION
### Proposed changes

This adds a CI pipeline to test if the usual way of building nginx and modules work.  This functionality is now not covered in the CI tests, and may be further expanded if/when https://github.com/nginxinc/nginx-otel/pull/27 is merged.

I've chosen Alpine as it has most of dependencies already built, which will drastically lower the time needed for checks to succeed or fail.  Also, this adds a test on the submitted PR.

Currently this fails due to https://github.com/nginxinc/nginx-otel/issues/16 and it will fail later on the actual test step - the perl tests seem to have protoc paths hardcoded to whatever is used by cmake-based build system.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-otel/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-otel/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-otel/blob/main/CHANGELOG.md))
