### PR TITLE
Bump actions/upload-artifact and actions/download-artifact from 3 to 4

### DIFF
--- a/.github/workflows/nginx-otel-module-check.yml
+++ b/.github/workflows/nginx-otel-module-check.yml
@@ -25,12 +25,12 @@ jobs:
           make -j 4
           strip ngx_otel_module.so
       - name: Archive module
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nginx-otel-module
           path: build/ngx_otel_module.so
       - name: Archive protoc and opentelemetry-proto
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: protoc-opentelemetry-proto
           path: |
@@ -43,12 +43,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Download module
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nginx-otel-module
           path: build
       - name: Download protoc and opentelemetry-proto
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: protoc-opentelemetry-proto
           path: build/_deps


### PR DESCRIPTION
### Proposed changes

Bumps [actions/download-artifact](https://github.com/actions/download-artifact)  and  [actions/upload-artifact](https://github.com/actions/upload-artifact) from 3 to 4.
