### PR TITLE
Provide -undefined dynamic_lookup on Mac (fix #38).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,10 @@ set_target_properties(ngx_otel_module PROPERTIES PREFIX "")
 # can't use OTel's WITH_ABSEIL until cmake 3.24, as it triggers find_package()
 target_compile_definitions(ngx_otel_module PRIVATE HAVE_ABSEIL)
 
+if (APPLE)
+    target_link_options(ngx_otel_module PRIVATE -undefined dynamic_lookup)
+endif()
+
 target_include_directories(ngx_otel_module PRIVATE
     ${NGX_OTEL_NGINX_BUILD_DIR}
     ${NGX_OTEL_NGINX_DIR}/src/core


### PR DESCRIPTION
### Proposed changes

This addresses linker errors when building the module on macOS allowing to symbols to be dynamically resolved upon loading the module in Nginx.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-otel/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
