### PR TITLE
Implementation of support for custom resource attributes

### DIFF
--- a/tests/h2_otel.t
+++ b/tests/h2_otel.t
@@ -47,6 +47,10 @@ http {
         batch_count 1;
     }
 
+	otel_resource_attr {
+		service.namespace 	test;
+	}
+
     otel_service_name test_server;
     otel_trace on;
 
@@ -159,7 +163,7 @@ foreach my $name ('localhost') {
 		or die "Can't create certificate for $name: $!\n";
 }
 
-$t->try_run('no OTel module')->plan(69);
+$t->try_run('no OTel module')->plan(70);
 
 ###############################################################################
 
@@ -211,6 +215,9 @@ is(scalar keys %{$$batch1{scope_spans}}, 5, 'batch1 size - trace on');
 is(get_attr("service.name", "string_value",
 	$$batch0{resource}),
 	'test_server', 'service.name - trace on');
+is(get_attr("service.namespace", "string_value",
+	$$batch0{resource}),
+	'test', 'service.namespace - trace on');
 is($$spans{span0}{name}, '"default_location"', 'span.name - trace on');
 
 #validate http metrics

--- a/tests/h3_otel.t
+++ b/tests/h3_otel.t
@@ -48,6 +48,10 @@ http {
         batch_count 2;
     }
 
+	otel_resource_attr {
+		service.namespace 	test;
+	}
+
     otel_service_name test_server;
     otel_trace on;
 
@@ -159,7 +163,7 @@ foreach my $name ('localhost') {
 		or die "Can't create certificate for $name: $!\n";
 }
 
-$t->try_run('no OTel module')->plan(56);
+$t->try_run('no OTel module')->plan(57);
 
 ###############################################################################
 
@@ -211,6 +215,9 @@ is(scalar keys %{$$batch1{scope_spans}}, 5, 'batch1 size - trace on');
 is(get_attr("service.name", "string_value",
 	$$batch0{resource}),
 	'test_server', 'service.name - trace on');
+is(get_attr("service.namespace", "string_value",
+	$$batch0{resource}),
+	'test', 'service.namespace - trace on');
 is($$spans{span0}{name}, '"default_location"', 'span.name - trace on');
 
 #validate metrics

--- a/tests/otel.t
+++ b/tests/otel.t
@@ -46,6 +46,10 @@ http {
         batch_count 2;
     }
 
+	otel_resource_attr {
+		service.namespace 	test;
+	}
+
     otel_service_name test_server;
     otel_trace on;
 
@@ -156,7 +160,7 @@ foreach my $name ('localhost') {
 		or die "Can't create certificate for $name: $!\n";
 }
 
-$t->try_run('no OTel module')->plan(69);
+$t->try_run('no OTel module')->plan(70);
 
 ###############################################################################
 
@@ -203,6 +207,9 @@ is(scalar keys %{$$batch1{scope_spans}}, 5, 'batch1 size - trace on');
 #validate general attributes
 is(get_attr("service.name", "string_value",
 	$$batch0{resource}), 'test_server', 'service.name - trace on');
+is(get_attr("service.namespace", "string_value",
+	$$batch0{resource}),
+	'test', 'service.namespace - trace on');
 is($$spans{span0}{name}, '"default_location"', 'span.name - trace on');
 
 #validate http metrics

--- a/tests/otel_collector.t
+++ b/tests/otel_collector.t
@@ -48,6 +48,10 @@ http {
         batch_count 2;
     }
 
+	otel_resource_attr {
+		service.namespace 	test;
+	}
+
     otel_service_name test_server;
     otel_trace on;
 
@@ -162,7 +166,7 @@ open STDERR, ">&", \*OLDERR;
 $t->waitforsocket('127.0.0.1:' . port(4317)) or
 	die 'No otel collector open socket';
 
-$t->try_run('no OTel module')->plan(69);
+$t->try_run('no OTel module')->plan(70);
 
 ###############################################################################
 
@@ -209,6 +213,9 @@ is(scalar @{${JSON::PP::decode_json($batches[1])}{"resourceSpans"}[0]
 is(get_attr("service.name", "stringValue",
 	$$batch_json{resourceSpans}[0]{resource}),
 	'test_server', 'service.name - trace on');
+is(get_attr("service.namespace", "stringValue",
+	$$batch_json{resourceSpans}[0]{resource}),
+	'test', 'service.namespace - trace on');
 is($$spans[0]{name}, 'default_location', 'span.name - trace on');
 
 #validate http metrics


### PR DESCRIPTION
### Proposed changes

This pull requests adds support for optional resources attributes. The resource attributes are configured, similar to what was suggested in the Issue #32, using a block configuration, e.g.
```
	otel_resource_attr {
		service.namespace 	test;
	}
```

fix [Custom Resource Attributes](https://github.com/nginxinc/nginx-otel/issues/32)

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-otel/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
