### PR TITLE
Support sending custom headers to export endpoint

### DIFF
--- a/src/batch_exporter.hpp
+++ b/src/batch_exporter.hpp
@@ -111,10 +111,10 @@ public:
         int attrSize{0};
     };
 
-    BatchExporter(StrView target, bool ssl, const std::string& trustedCert,
+    BatchExporter(const Target& target,
             size_t batchSize, size_t batchCount,
             const std::map<StrView, StrView>& resourceAttrs) :
-        batchSize(batchSize), client(std::string(target), ssl, trustedCert)
+        batchSize(batchSize), client(target)
     {
         free.reserve(batchCount);
         while (batchCount-- > 0) {

--- a/src/http_module.cpp
+++ b/src/http_module.cpp
@@ -711,7 +711,8 @@ char* addResourceAttr(ngx_conf_t* cf, ngx_command_t* cmd, void* conf)
     return NGX_CONF_OK;
 }
 
-char* setTrustedCertificate(ngx_conf_t* cf, ngx_command_t* cmd, void* conf) {
+char* setTrustedCertificate(ngx_conf_t* cf, ngx_command_t* cmd, void* conf)
+{
     auto path = ((ngx_str_t*)cf->args->elts)[1];
     auto mcf = getMainConf(cf);
 
@@ -727,11 +728,13 @@ char* setTrustedCertificate(ngx_conf_t* cf, ngx_command_t* cmd, void* conf) {
             return (char*)NGX_CONF_ERROR;
         }
         file.exceptions(std::ios::failbit | std::ios::badbit);
-        file.seekg(0, std::ios::end);
-        size_t size = file.tellg();
-        mcf->trustedCert.resize(size);
+        file.peek(); // trigger early error for dirs
+
+        size_t size = file.seekg(0, std::ios::end).tellg();
         file.seekg(0);
-        file.read(&mcf->trustedCert[0], mcf->trustedCert.size());
+
+        mcf->trustedCert.resize(size);
+        file.read(&mcf->trustedCert[0], size);
     } catch (const std::exception& e) {
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
             "failed to read \"%V\": %s", &path, e.what());

--- a/src/http_module.cpp
+++ b/src/http_module.cpp
@@ -576,10 +576,13 @@ ngx_int_t initWorkerProcess(ngx_cycle_t* cycle)
     }
 
     try {
+        Target target;
+        target.endpoint = std::string(toStrView(mcf->endpoint));
+        target.ssl = mcf->ssl;
+        target.trustedCert = mcf->trustedCert;
+
         gExporter.reset(new BatchExporter(
-            toStrView(mcf->endpoint),
-            mcf->ssl,
-            mcf->trustedCert,
+            target,
             mcf->batchSize,
             mcf->batchCount,
             mcf->resourceAttrs));
@@ -772,7 +775,7 @@ void* createMainConf(ngx_conf_t* cf)
 
 char* initMainConf(ngx_conf_t* cf, void* conf)
 {
-    auto mcf = (MainConf*)conf;
+    auto mcf = getMainConf(cf);
 
     ngx_conf_init_msec_value(mcf->interval, 5000);
     ngx_conf_init_size_value(mcf->batchSize, 512);


### PR DESCRIPTION
The headers are configured by "header" directive in "otel_exporter" block, e.g.
```
    otel_exporter {
        endpoint localhost:4317;
        header X-API-Token "token value";
    }
```
