### PR TITLE
fix: building error with ssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ cd nginx
 auto/configure --with-compat
 ```
 
+Make sure the SSL module is enabled before compiling.
+
+```
+auto/configure --with-http_ssl_module
+```
+
 Exit the NGINX directory and clone the `ngx_otel_module` repository.
 ```bash
 cd ..


### PR DESCRIPTION
### Proposed changes

Ref https://github.com/nginxinc/nginx-otel/issues/89

Nginx SSL module should be enabled before compiling.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-otel/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
