### PR TITLE
Fix build with absolute --builddir= values.

### DIFF
--- a/config
+++ b/config
@@ -1,7 +1,13 @@
 ngx_addon_name=ngx_otel_module
 
-cmake -D NGX_OTEL_NGINX_BUILD_DIR=$NGX_OBJS \
-      -D CMAKE_LIBRARY_OUTPUT_DIRECTORY=$PWD/$NGX_OBJS \
+case "$NGX_OBJS" in
+    /*) ngx_module_outdir="$NGX_OBJS" ;;
+    *)  ngx_module_outdir="$PWD/$NGX_OBJS" ;;
+esac
+
+cmake -D "NGX_OTEL_NGINX_DIR=$PWD" \
+      -D "NGX_OTEL_NGINX_BUILD_DIR=$NGX_OBJS" \
+      -D "CMAKE_LIBRARY_OUTPUT_DIRECTORY=$ngx_module_outdir" \
       -D "CMAKE_C_FLAGS=$NGX_CC_OPT" \
       -D "CMAKE_CXX_FLAGS=$NGX_CC_OPT" \
       -D "CMAKE_MODULE_LINKER_FLAGS=$NGX_LD_OPT" \


### PR DESCRIPTION
This fixes two issues with `auto/configure --builddir=/tmp/nginx-otel-build`:

```
[ 20%] Building CXX object CMakeFiles/ngx_otel_module.dir/src/http_module.cpp.o
In file included from /home/bavshin/sources/nginx/nginx-otel/src/http_module.cpp:1:
/home/bavshin/sources/nginx/nginx-otel/src/ngx.hpp:4:10: fatal error: ngx_config.h: No such file or directory
    4 | #include <ngx_config.h>
      |          ^~~~~~~~~~~~~~
```

```
[ 90%] Linking CXX shared module /home/bavshin/sources/nginx/nginx/tmp/nginx-otel-build/ngx_otel_module.so
```