### PR TITLE
ci: pin actions to full commit SHAs

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -12,14 +12,14 @@ jobs:
     container: alpine
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install dependencies
         run: |
           apk add build-base openssl-dev zlib-dev pcre2-dev \
                   cmake git grpc-dev protobuf-dev \
                   python3
       - name: Checkout nginx
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: nginx/nginx
           path: nginx

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake libc-ares-dev
       - name: Checkout nginx
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: nginx/nginx
           path: nginx


### PR DESCRIPTION
## Summary

Pin action refs from mutable tags to full commit SHAs to prevent supply-chain attacks.

## Changes

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `v6` | `de0fac2e...` |

Applied to: `alpine.yml`, `ubuntu.yml`

No behavioral changes — supply-chain hardening only.