### PR TITLE
Fix build with C++20.

### DIFF
--- a/src/http_module.cpp
+++ b/src/http_module.cpp
@@ -859,6 +859,8 @@ template <class Id>
 ngx_int_t hexIdVar(ngx_http_request_t* r, ngx_http_variable_value_t* v,
     uintptr_t data)
 {
+    namespace nostd = opentelemetry::nostd;
+
     auto ctx = ensureOtelCtx(r);
     if (!ctx) {
         return NGX_ERROR;
@@ -867,13 +869,13 @@ ngx_int_t hexIdVar(ngx_http_request_t* r, ngx_http_variable_value_t* v,
     auto id = (Id*)((char*)ctx + data);
 
     if (id->IsValid()) {
-        auto size = id->Id().size() * 2;
+        constexpr auto size = 2 * Id::kSize;
         auto buf = (char*)ngx_pnalloc(r->pool, size);
         if (buf == NULL) {
             return NGX_ERROR;
         }
 
-        id->ToLowerBase16({buf, size});
+        id->ToLowerBase16(nostd::span<char, size>{buf, size});
 
         v->len = size;
         v->valid = 1;

--- a/src/trace_context.hpp
+++ b/src/trace_context.hpp
@@ -67,16 +67,19 @@ struct TraceContext {
     static void serialize(const TraceContext& tc, char* out)
     {
         using namespace opentelemetry::trace::propagation;
+        namespace nostd = opentelemetry::nostd;
 
         *out++ = '0';
         *out++ = '0';
         *out++ = '-';
 
-        tc.traceId.ToLowerBase16({out, kTraceIdSize});
+        tc.traceId.ToLowerBase16(
+            nostd::span<char, kTraceIdSize>{out, kTraceIdSize});
         out += kTraceIdSize;
         *out++ = '-';
 
-        tc.spanId.ToLowerBase16({out, kSpanIdSize});
+        tc.spanId.ToLowerBase16(
+            nostd::span<char, kSpanIdSize>{out, kSpanIdSize});
         out += kSpanIdSize;
         *out++ = '-';
 


### PR DESCRIPTION
OpenTelemetry SDK built with C++20 uses std::span in the API, and we want to match the standard to avoid type changes at the API boundary.

However, std::span constructor is explicit for non-default Extent, requiring us to use a more verbose specification instead of an initializer list.

```
src/trace_context.hpp:75:33: error: converting to ‘opentelemetry::v1::nostd::span<char, 32>’ {aka ‘std::span<char, 32>’} from initializer list would use explicit constructor ‘constexpr std::span<_Type, _Extent>::span(_It, size_type) [with _It = char*; _Type = char; long unsigned int _Extent = 32; size_type = long unsigned int]’
   75 |         tc.traceId.ToLowerBase16({out, kTraceIdSize});
      |         ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
```