### PR TITLE
Fix trace context injection for subrequests.

### DIFF
--- a/src/http_module.cpp
+++ b/src/http_module.cpp
@@ -291,6 +291,15 @@ ngx_int_t setHeader(ngx_http_request_t* r, StrView name, StrView value)
             return NGX_ERROR;
         }
 
+        // Subrequests shallow-copy ngx_list_t from the main request.  Recompute
+        // last so appended headers are visible through this request's list head.
+        for (auto part = &headers->part; part; part = part->next) {
+            if (part->next == NULL) {
+                headers->last = part;
+                break;
+            }
+        }
+
         header = (ngx_table_elt_t*)ngx_list_push(headers);
         if (header == NULL) {
             return NGX_ERROR;
@@ -353,8 +362,35 @@ OtelCtx* ensureOtelCtx(ngx_http_request_t* r)
     return ctx;
 }
 
+ngx_int_t injectSubrequest(ngx_http_request_t* r)
+{
+    // Subrequests (SSI 'include virtual', auth_request, mirror, ...) may share
+    // the main request's trace context, so they must not make their own sampling
+    // decision (that would clobber the shared ctx->current.sampled). Their only
+    // job here is to carry trace context onto an upstream proxy call.
+    auto lcf = getLocationConf(r);
+    if (!(lcf->traceContext & Propagation::Inject)) {
+        return NGX_DECLINED;
+    }
+
+    auto ctx = ensureOtelCtx(r);
+    if (!ctx) {
+        return NGX_ERROR;
+    }
+
+    auto rc = inject(r, ctx->current);
+    return rc == NGX_OK ? NGX_DECLINED : rc;
+}
+
 ngx_int_t onRequestStart(ngx_http_request_t* r)
 {
+    // Subrequests are flagged r->internal too, but unlike internal redirects
+    // they may proxy upstream and must still inject the inherited trace
+    // context. Handle them on a dedicated inject-only path.
+    if (r != r->main) {
+        return injectSubrequest(r);
+    }
+
     // don't let internal redirects to override sampling decision
     if (r->internal) {
         return NGX_DECLINED;

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -93,6 +93,25 @@ http {
             add_header "X-Otel-Tracestate" $http_tracestate;
             return 204;
         }
+
+        # SSI page that pulls in an internal subrequest via proxy_pass (#119)
+        location = /page.html {
+            otel_trace off;
+            ssi on;
+        }
+
+        location = /_frag {
+            internal;
+            otel_trace off;
+            otel_trace_context propagate;
+            proxy_pass http://127.0.0.1:18080/echo_tp;
+        }
+
+        # backend echoing the traceparent it received into the body
+        location = /echo_tp {
+            otel_trace off;
+            return 200 $http_traceparent;
+        }
     }
 }
 
@@ -238,6 +257,35 @@ def test_context(client, trace_service, parent, path):
 
     assert r.headers.get("X-Otel-Traceparent") == headers["Traceparent"]
     assert r.headers.get("X-Otel-Tracestate") == headers["Tracestate"]
+
+
+@pytest.mark.parametrize("parent", [None, parent_ctx])
+def test_subrequest_inject(client, trace_service, testdir, parent):
+    # #119: an SSI `include virtual` subrequest that proxies upstream must
+    # still get a traceparent injected on its upstream call. The subrequest
+    # is flagged r->internal, so the early `if (r->internal)` guard in
+    # onRequestStart used to drop it before the inject path.
+    (testdir / "page.html").write_text('x<!--# include virtual="/_frag" -->x')
+
+    r = client.get(
+        "http://127.0.0.1:18080/page.html", headers=trace_headers(parent)
+    )
+
+    # body is "x" + (traceparent echoed by backend) + "x"
+    echoed = r.text[1:-1]
+
+    if parent:
+        # subrequest must propagate the parent's trace id downstream...
+        assert echoed.startswith(f"00-{parent.trace_id}-")
+        # ...under a fresh nginx span, not the parent's span id. Without the
+        # fix, proxy_pass merely forwards the inbound traceparent verbatim
+        # (still carrying the parent's span id), so this guards against that
+        # false positive and proves the inject path actually ran.
+        assert not echoed.startswith(f"00-{parent.trace_id}-{parent.span_id}-")
+    else:
+        # no inbound context: a fresh trace id is generated and injected
+        assert echoed.startswith("00-")
+        assert len(echoed) == 55  # 00-<32>-<16>-<2>
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
  ### Proposed changes

  `onRequestStart` returns early on `r->internal` so that internal redirects don't
  override the sampling decision. Genuine subrequests (SSI `include virtual`,
  `auth_request`, `mirror`, …) carry that flag too, so they hit the same early
  return: the inject path never ran, and an upstream `proxy_pass` issued from
  within a subrequest went out without a `traceparent` — starting a new trace
  instead of nesting under the originating page request.

  This separates subrequests (`r != r->main`) from internal redirects and routes
  them to a dedicated, inject-only path (`injectSubrequest`). A subrequest now
  injects the trace context inherited from the main request onto its upstream
  call, while deliberately *not* making its own sampling decision (which would
  clobber the shared `ctx->current.sampled`).

  It also corrects `setHeader` for subrequests: a subrequest shallow-copies the
  main request's header `ngx_list_t`, so `headers->last` is recomputed before
  pushing — otherwise the appended `traceparent` is invisible through the
  subrequest's own list head.

  Added `test_subrequest_inject` covering both an inbound parent context (the
  subrequest must propagate the parent trace id under a fresh nginx span) and no
  inbound context (a fresh trace id is generated and injected).

  ### Trace flow before / after

  Verified against Elastic APM (the fix itself is backend-agnostic). Sensitive
  fields redacted.

  **Before** — the subrequest's `proxy_pass` starts a separate, disconnected trace:

  
<img width="1920" height="972" alt="image" src="https://github.com/user-attachments/assets/d6492b67-5e38-4d43-a761-5b392fd894e4" />


  **After** — the upstream call nests as a child span under the page request:

  <img width="1920" height="972" alt="image" src="https://github.com/user-attachments/assets/67652b83-cc66-4202-85b8-0d0900daac70" />

  Fixes #119

  ### Checklist

  Before creating a PR, run through this checklist and mark each as complete.

  - [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/nginx-otel/blob/main/CONTRIBUTING.md) document
  - [x] If applicable, I have added tests that prove my fix is effective or that my feature works
  - [x] If applicable, I have checked that any relevant tests pass after adding my changes